### PR TITLE
Test funcionales y cambio en la entrada del body endpoint refund

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -24,5 +24,4 @@ class RefundSerializer(serializers.Serializer):
         and create the JSON
     """
 
-    user_id = serializers.IntegerField(source="user.id")
     route_id = serializers.PrimaryKeyRelatedField(queryset=Route.objects.all())

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/api/tests/test_payment.py
+++ b/api/tests/test_payment.py
@@ -1,0 +1,188 @@
+from common.models import route
+from rest_framework.test import APITestCase
+from rest_framework.reverse import reverse
+from rest_framework import status
+from django.conf import settings
+
+from common.models.user import ChargerType, User, Driver, Preference
+from common.models.route import Route
+from common.models.payment import Payment
+
+import stripe
+import json
+from rest_framework.authtoken.models import Token
+
+
+def createPaymentMethodId():
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+
+    payment_method = stripe.PaymentMethod.create(type="card", card={"token": "tok_visa"})
+
+    return payment_method.id
+
+
+class CreatePaymentViewTest(APITestCase):
+    """
+    Test the CreatePaymentView view.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username="test",
+            birthDate="1998-10-06",
+            password="test",
+            email="test@gmail.com",
+        )
+        chargerType = ChargerType.objects.create(chargerType="Mennekes")
+        self.driver = Driver.objects.create(
+            username="driver1",
+            birthDate="1998-10-06",
+            email="driver@gmail.com",
+            password="driver",
+            dni="12345678",
+            preference=Preference.objects.create(),
+            iban="ES662100999",
+        )
+        self.driver.chargerTypes.add(chargerType)
+        self.token, _ = Token.objects.get_or_create(user=self.user)
+        self.route = Route.objects.create(
+            driver=self.driver,
+            originLat=41.389972,
+            originLon=2.115333,
+            originAlias="BSC - Supercomputing Center",
+            destinationLat=42.244062,
+            destinationLon=-6.269438,
+            destinationAlias="Morla de la Valdería",
+            price=10.0,
+            distance=852896,
+            duration=30177,
+            departureTime="2024-10-06T10:00:00Z",
+            freeSeats=4,
+        )
+        self.route.passengers.add(self.user)
+
+    def testSuccessfulPayment(self):
+        """
+        Ensure the API call creates a payments in Stripe and a payment in the database.
+        """
+
+        paymentMethodId = createPaymentMethodId()
+        url = reverse("process-payment")
+        data = {
+            "payment_method_id": paymentMethodId,
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        message = json.loads(response.content.decode("utf-8"))  # Decode the response to JSON
+        self.assertEqual(message.get("message"), "Payment processed successfully.")
+
+        try:
+            payment = Payment.objects.get(user=self.user, route=self.route)
+        except Payment.DoesNotExist:
+            payment = None
+        self.assertIsNotNone(payment)
+
+        if payment is not None:
+            self.assertEqual(payment.amount, self.route.price)
+            self.assertEqual(payment.isRefunded, False)
+            self.assertIsNotNone(payment.paymentIntentId)
+
+    def testNeedsPaymentId(self):
+        """
+        Ensure the API call returns an error if the payment method id is not provided.
+        """
+
+        url = reverse("process-payment")
+        data = {
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "Payment method ID is required.")
+
+    def testIncorrectPaymentId(self):
+        """
+        Ensure the API call returns an error if the payment method id is not incorrect.
+        """
+
+        url = reverse("process-payment")
+        data = {
+            "payment_method_id": "123",
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def testIncorrectRouteId(self):
+        """
+        Ensure the API call returns an error if the route id is not provided or it is incorrect.
+        """
+
+        paymentMethodId = createPaymentMethodId()
+        url = reverse("process-payment")
+        data = {
+            "payment_method_id": paymentMethodId,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "Route not exist.")
+
+        data2 = {
+            "payment_method_id": paymentMethodId,
+            "route_id": 100,
+        }
+        response = self.client.post(url, data2, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "Route not exist.")
+
+    def testErrorPayTwice(self):
+        """
+        Ensure the API call returns an error if the user has already paid for the route.
+        """
+
+        paymentMethodId = createPaymentMethodId()
+        url = reverse("process-payment")
+        data = {
+            "payment_method_id": paymentMethodId,
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "You have already paid for this route.")
+
+    def testUnauthorized(self):
+        """
+        Ensure the API call returns an error if the user is not authenticated.
+        """
+
+        paymentMethodId = createPaymentMethodId()
+        url = reverse("process-payment")
+        data = {
+            "payment_method_id": paymentMethodId,
+            "route_id": self.route.pk,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/api/tests/test_refund.py
+++ b/api/tests/test_refund.py
@@ -1,0 +1,205 @@
+from email import message
+from re import S
+from common.models import route
+from rest_framework.test import APITestCase
+from rest_framework.reverse import reverse
+from rest_framework import status
+from django.conf import settings
+
+from common.models.user import ChargerType, User, Driver, Preference
+from common.models.route import Route
+from common.models.payment import Payment
+
+import stripe
+import json
+from rest_framework.authtoken.models import Token
+
+
+def createPaymentMethodId():
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+
+    payment_method = stripe.PaymentMethod.create(type="card", card={"token": "tok_visa"})
+
+    return payment_method.id
+
+
+class CreateRefundViewTest(APITestCase):
+    """
+    Test the CreateRefundView view.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username="test",
+            birthDate="1998-10-06",
+            password="test",
+            email="test@gmail.com",
+        )
+        chargerType = ChargerType.objects.create(chargerType="Mennekes")
+        self.driver = Driver.objects.create(
+            username="driver1",
+            birthDate="1998-10-06",
+            email="driver@gmail.com",
+            password="driver",
+            dni="12345678",
+            preference=Preference.objects.create(),
+            iban="ES662100999",
+        )
+        self.driver.chargerTypes.add(chargerType)
+        self.token, _ = Token.objects.get_or_create(user=self.user)
+        self.route = Route.objects.create(
+            driver=self.driver,
+            originLat=41.389972,
+            originLon=2.115333,
+            originAlias="BSC - Supercomputing Center",
+            destinationLat=42.244062,
+            destinationLon=-6.269438,
+            destinationAlias="Morla de la Valdería",
+            price=10.0,
+            distance=852896,
+            duration=30177,
+            departureTime="2024-10-06T10:00:00Z",
+            freeSeats=4,
+        )
+        self.route.passengers.add(self.user)
+
+    def testSuccessfulRefund(self):
+        """
+        Ensure the API call refund a payment in Stripe and a payment in set as refunded.
+        """
+        paymentMethodId = createPaymentMethodId()
+        url_payment = reverse("process-payment")
+        data_payment = {
+            "payment_method_id": paymentMethodId,
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+
+        self.client.post(url_payment, data_payment, format="json", headers=headers)  # type: ignore
+
+        url_refund = reverse("refund")
+        data_refund = {
+            "route_id": self.route.pk,
+        }
+        response = self.client.post(url_refund, data_refund, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        message = json.loads(response.content.decode("utf-8"))  # Decode the response to JSON
+        self.assertEqual(message.get("message"), "Refund processed successfully.")
+
+        payment = Payment.objects.get(user=self.user, route=self.route)
+        self.assertEqual(payment.isRefunded, True)
+
+    def testIncorrectRoute(self):
+        """
+        Ensure the API call returns an error if the route id is not provided or it is incorrect.
+        """
+        url = reverse("refund")
+        data = {}
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "Route not exist.")
+
+        data2 = {
+            "route_id": 999,
+        }
+        response = self.client.post(url, data2, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "Route not exist.")
+
+    def testCantRefundUserNotPaid(self):
+        """
+        Ensure the API call returns an error if the user has not paid for the route and try to make a refund.
+        """
+        url = reverse("refund")
+        data = {
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        response = self.client.post(url, data, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "User has not paid for this route.")
+
+    def testErrorRefundTwice(self):
+        """
+        Ensure the API call returns an error if the user has already refunded the route.
+        """
+        paymentMethodId = createPaymentMethodId()
+        url_payment = reverse("process-payment")
+        data_payment = {
+            "payment_method_id": paymentMethodId,
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+
+        self.client.post(url_payment, data_payment, format="json", headers=headers)  # type: ignore
+
+        url_refund = reverse("refund")
+        data_refund = {
+            "route_id": self.route.pk,
+        }
+        response = self.client.post(url_refund, data_refund, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.post(url_refund, data_refund, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("error"), "User has not paid for this route.")
+
+    def testRefundDifferentPaymentSameUserRoute(self):
+        """
+        Ensure the API call keep one instance of the payment although the user has paid and refunded multiple times.
+        """
+        paymentMethodId = createPaymentMethodId()
+        url_payment = reverse("process-payment")
+        data_payment = {
+            "payment_method_id": paymentMethodId,
+            "route_id": self.route.pk,
+        }
+        headers = {
+            "Authorization": f"Token {self.token}",
+        }
+        self.client.post(url_payment, data_payment, format="json", headers=headers)  # type: ignore
+
+        url_refund = reverse("refund")
+        data_refund = {
+            "route_id": self.route.pk,
+        }
+        self.client.post(url_refund, data_refund, format="json", headers=headers)  # type: ignore
+
+        paymentMethodId2 = createPaymentMethodId()
+        data_payment_2 = {
+            "payment_method_id": paymentMethodId2,
+            "route_id": self.route.pk,
+        }
+        self.client.post(url_payment, data_payment_2, format="json", headers=headers)  # type: ignore
+
+        response = self.client.post(url_refund, data_refund, format="json", headers=headers)  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        message = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(message.get("message"), "Refund processed successfully.")
+
+        payment = len(Payment.objects.filter(user=self.user, route=self.route, isRefunded=True))
+        self.assertEqual(payment, 2)
+
+    def testUnauthorized(self):
+        """
+        Ensure the API call returns an error if the user is not authenticated.
+        """
+        url_refund = reverse("refund")
+        data_refund = {
+            "route_id": self.route.pk,
+        }
+        response = self.client.post(url_refund, data_refund, format="json")  # type: ignore
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,6 @@ typing_extensions==4.11.0
 tzdata==2024.1
 uritemplate==4.1.1
 urllib3==2.2.1
+boto3
+django-storages==1.14.0
+pillow


### PR DESCRIPTION
Tests funcionales de pagos (cada vez que se ejecuta el python manage.py tests, me llegan 10 llamadas API al Stripe, no metáis esto en bucle pls).
He cambiado también que el body del refund solo necesite la ruta.
Actualmente el modelo Payments puede guardar un mismo user y mismo ruta más de una vez, siempre y cuando estén en estado refund. Es decir, solo puede haber un payment con un user, un route y isRefund a false en cualquier momento. (Esto es así porque puede que un usuario se una a una ruta, se vaya, pero luego decida volver a entrar)